### PR TITLE
Fix an issue with nav-drawer since moodle last version

### DIFF
--- a/amd/build/pimenko.min.js
+++ b/amd/build/pimenko.min.js
@@ -1,1 +1,1 @@
-"use strict";define(["jquery"],function(t){return{init:function(){t(function(){t("#completion-block").tooltip({trigger:"hover"})})}}});
+"use strict";define(["jquery"],function(e){let t=function(){return window.pageYOffset||document.documentElement.scrollTop};return{init:function(){e(function(){e("#completion-block").tooltip({trigger:"hover"})}),this.scrollY=0,window.addEventListener("scroll",function(){const e=document.querySelector("body");t()>=window.innerHeight?e.classList.add("scrolled"):e.classList.remove("scrolled")}.bind(this))}}});

--- a/amd/src/pimenko.js
+++ b/amd/src/pimenko.js
@@ -18,6 +18,7 @@
  * @copyright  Pimenko 2019
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
 "use strict";
 define(['jquery'],
     function($) {
@@ -30,9 +31,31 @@ define(['jquery'],
             });
         };
 
+        /**
+         * Add special classes to body depending on scroll position.
+         *
+         * @method  update
+         * @chainable
+         */
+        let scrollHandler = function() {
+            const body = document.querySelector('body');
+            const scrollY = getScrollPosition();
+            if (scrollY >= window.innerHeight) {
+                body.classList.add('scrolled');
+            } else {
+                body.classList.remove('scrolled');
+            }
+        };
+
+        let getScrollPosition = function() {
+            return window.pageYOffset || document.documentElement.scrollTop;
+        };
+
         return {
             init: function() {
                 eventlistener();
+                this.scrollY = 0;
+                window.addEventListener("scroll", scrollHandler.bind(this));
             }
         };
     });

--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -63,19 +63,7 @@ final class core_renderer extends \theme_boost\output\core_renderer {
     public function render_login_page($output): string {
         global $SITE;
 
-        // We check if the user is connected and we set the drawer to close.
-        if (isloggedin()) {
-            $navdraweropen = (get_user_preferences(
-                            'drawer-open-nav', 'false'
-                    ) == 'false');
-        } else {
-            $navdraweropen = false;
-        }
-
         $extraclasses = [];
-        if ($navdraweropen) {
-            $extraclasses[] = 'drawer-open-left';
-        }
 
         // Define some needed var for ur template.
         $template = new stdClass();

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -29,16 +29,7 @@ require_once($CFG->libdir . '/behat/lib.php');
 
 theme_pimenko_redirect_to_profile_page($PAGE->bodyid);
 
-if (isloggedin()) {
-    $navdraweropen = (get_user_preferences('drawer-open-nav', 'true') == 'true');
-} else {
-    $navdraweropen = false;
-}
-
 $extraclasses = [];
-if ($navdraweropen) {
-    $extraclasses[] = 'drawer-open-left';
-}
 
 $PAGE->requires->js_call_amd('theme_pimenko/pimenko', 'init');
 $PAGE->requires->js_call_amd('theme_pimenko/completion', 'init');
@@ -50,15 +41,27 @@ $buildregionmainsettings = !$PAGE->include_region_main_settings_in_header_action
 
 // If the settings menu will be included in the header then don't add it here.
 $regionmainsettingsmenu = $buildregionmainsettings ? $OUTPUT->region_main_settings_menu() : false;
+
+$renderer = $PAGE->get_renderer('core');
+$primary = new core\navigation\output\primary($PAGE);
+$primarymenu = $primary->export_for_template($renderer);
+
+$secondarynavigation = false;
+if ($PAGE->has_secondary_navigation()) {
+    $moremenu = new \core\navigation\output\more_menu($PAGE->secondarynav, 'nav-tabs');
+    $secondarynavigation = $moremenu->export_for_template($OUTPUT);
+}
+
 $templatecontext = [
         'sitename' => format_string($SITE->shortname, true, ['context' => context_course::instance(SITEID), "escape" => false]),
         'output' => $OUTPUT,
         'sidepreblocks' => $blockshtml,
         'hasblocks' => $hasblocks,
         'bodyattributes' => $bodyattributes,
-        'navdraweropen' => $navdraweropen,
         'regionmainsettingsmenu' => $regionmainsettingsmenu,
-        'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu)
+        'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu),
+        'primarymoremenu' => $primarymenu['moremenu'],
+        'secondarymoremenu' => $secondarynavigation ?: false,
 ];
 
 $nav = $PAGE->flatnav;

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -27,15 +27,8 @@ defined('MOODLE_INTERNAL') || die();
 user_preference_allow_ajax_update( 'drawer-open-nav', PARAM_ALPHA);
 require_once($CFG->libdir . '/behat/lib.php');
 
-if (isloggedin()) {
-    $navdraweropen = (get_user_preferences('drawer-open-nav', 'true') == 'true');
-} else {
-    $navdraweropen = false;
-}
 $extraclasses = [];
-if ($navdraweropen) {
-    $extraclasses[] = 'drawer-open-left';
-}
+
 $bodyattributes = $OUTPUT->body_attributes($extraclasses);
 $blockshtml = $OUTPUT->blocks('side-pre');
 $hasblocks = strpos( $blockshtml, 'data-block=' ) !== false;
@@ -44,6 +37,17 @@ $buildregionmainsettings = !$PAGE->include_region_main_settings_in_header_action
 $regionmainsettingsmenu = $buildregionmainsettings ? $OUTPUT->region_main_settings_menu() : false;
 $hasfrontpageregions = $OUTPUT->get_block_regions();
 $iscarouselenabled = $OUTPUT->is_carousel_enabled();
+
+$renderer = $PAGE->get_renderer('core');
+$primary = new core\navigation\output\primary($PAGE);
+$primarymenu = $primary->export_for_template($renderer);
+
+$secondarynavigation = false;
+if ($PAGE->has_secondary_navigation()) {
+    $moremenu = new \core\navigation\output\more_menu($PAGE->secondarynav, 'nav-tabs');
+    $secondarynavigation = $moremenu->export_for_template($OUTPUT);
+}
+
 $templatecontext = [
         'sitename' => format_string(
                 $SITE->shortname,
@@ -57,11 +61,12 @@ $templatecontext = [
         'sidepreblocks' => $blockshtml,
         'hasblocks' => $hasblocks,
         'bodyattributes' => $bodyattributes,
-        'navdraweropen' => $navdraweropen,
         'regionmainsettingsmenu' => $regionmainsettingsmenu,
         'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu),
         'hasfrontpageregions' => !empty($hasfrontpageregions),
         'iscarouselenabled' => $iscarouselenabled,
+        'primarymoremenu' => $primarymenu['moremenu'],
+        'secondarymoremenu' => $secondarynavigation ?: false,
 ];
 
 // Include js module.

--- a/scss/body.scss
+++ b/scss/body.scss
@@ -107,12 +107,31 @@ body {
     .block_html {
         background: none;
     }
+}
 
-    #goto-top-link .btn {
-        float: right;
+body.scrolled #goto-top-link {
+    opacity: 1;
+    visibility: visible;
+    transition: visibility 0s ease 0s, opacity .7s ease .1s;
+}
 
-        .icon {
-            margin: 0;
-        }
+@include media-breakpoint-down(sm) {
+    #goto-top-link {
+        bottom: 0;
+    }
+}
+
+#goto-top-link {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity .7s ease 0s, visibility .1s ease .8s;
+    display: block;
+    position: fixed;
+    bottom: $gototop-bottom-position;
+    right: 0;
+    a {
+        position: absolute;
+        right: 0;
+        transform: translateY(-100%);
     }
 }

--- a/scss/moodle.scss
+++ b/scss/moodle.scss
@@ -21,6 +21,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+@import 'variables';
 @import '../../boost/scss/moodle';
 @import 'body';
 @import 'login';

--- a/scss/navbar.scss
+++ b/scss/navbar.scss
@@ -126,3 +126,26 @@ nav.navbar.pimenko-navbar.fixed-top {
         }
     }
 }
+
+.secondary-navigation {
+    margin: 10px 0;
+}
+
+.primary-navigation {
+    .moremenu .nav-link {
+        &:hover,
+        &:focus {
+            background: none;
+        }
+
+        &.active {
+            border: none;
+            color: unquote('darkennavcolor') !important;
+        }
+    }
+
+}
+
+.moremenu .nav-link.active {
+    border-bottom-color: unquote('brandcolorbutton');
+}

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,0 +1,2 @@
+// Floating elements positions
+$gototop-bottom-position: 50px !default;

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -58,7 +58,6 @@
     {{{ output.standard_top_of_body_html }}}
 
     {{> theme_boost/navbar }}
-    {{> theme_boost/nav-drawer }}
 
     <div id="page" class="container-fluid">
         <div id="page-content" class="row">

--- a/templates/login.mustache
+++ b/templates/login.mustache
@@ -50,7 +50,6 @@
             <!-- Default navbar. -->
             {{> theme_boost/navbar }}
             <!-- Default nav-drawer. -->
-            {{> theme_boost/nav-drawer }}
             <div class="container outercont">
                 <div id="page-content" class="row">
                     <section id="region-main" class="col-12">

--- a/templates/theme_boost/columns2.mustache
+++ b/templates/theme_boost/columns2.mustache
@@ -57,11 +57,14 @@
     {{{ output.standard_top_of_body_html }}}
 
     {{> theme_boost/navbar }}
-    {{> theme_boost/nav-drawer }}
 
     <div id="page" class="container-fluid d-print-block">
         {{{ output.full_header }}}
-
+        {{#secondarymoremenu}}
+            <div class="secondary-navigation">
+                {{> core/moremenu}}
+            </div>
+        {{/secondarymoremenu}}
         <div id="page-content" class="row pb-3 d-print-block">
             <div id="region-main-box" class="col-12">
                 {{#hasregionmainsettingsmenu}}

--- a/templates/theme_boost/navbar.mustache
+++ b/templates/theme_boost/navbar.mustache
@@ -19,13 +19,6 @@
 }}
 <nav class="fixed-top navbar navbar-light bg-white navbar-expand moodle-has-zindex pimenko-navbar" aria-label="{{#str}}sitemenubar, admin{{/str}}">
 
-    <div class="d-flex" data-region="drawer-toggle">
-        <button class="navbar-toggler aabtn d-block my-1 mr-2" aria-expanded="{{#navdraweropen}}true{{/navdraweropen}}{{^navdraweropen}}false{{/navdraweropen}}" aria-controls="nav-drawer" type="button" data-action="toggle-drawer" data-side="left" data-preference="drawer-open-nav">
-            <span class="navbar-toggler-icon"></span>
-            <span class="sr-only">{{#str}}sidepanel, core{{/str}}</span>
-        </button>
-    </div>
-
     <a href="{{{ config.wwwroot }}}" class="navbar-brand aabtn {{# output.sitelogo }}has-logo{{/ output.sitelogo }}
         {{^ output.sitelogo }}
                 d-none d-sm-inline
@@ -38,6 +31,14 @@
         {{/ output.sitelogo }}
         <span class="site-name d-none d-md-inline">{{{ sitename }}}</span>
     </a>
+
+    {{#primarymoremenu}}
+        <div class="primary-navigation">
+            {{> core/moremenu}}
+        </div>
+    {{/primarymoremenu}}
+
+
 
     <ul class="navbar-nav d-none d-md-flex">
         <!-- custom_menu -->

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = '2021042205';
+$plugin->version = '2021042206';
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = '2019111800';


### PR DESCRIPTION
1. Fix an issue with moodle last version and the display of nav-drawer.
Note about this : at this point we decide to remove the nav-drawer from theme_pimenko, also some code related to this changes have been removed
2. Moodle removed "go to top", so I fixed the missing part in our theme to make it work.
3. Add primary and secondary navigation menu.