### PR TITLE
Add option to show/hide navigation in mod

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -70,7 +70,12 @@ final class core_renderer extends \theme_boost\output\core_renderer {
      * @return bool
      */
     public function show_activity_navigation(): bool {
-        return true;
+        $themeconfig = theme_config::load('pimenko');
+        $showactivitynav = false;
+        if ($themeconfig->settings->showactivitynavigation) {
+            $showactivitynav = true;
+        }
+        return $showactivitynav;
     }
 
     /**

--- a/config.php
+++ b/config.php
@@ -92,6 +92,12 @@ $THEME->layouts = [
         'defaultregion' => 'side-pre',
         'options' => array('langmenu' => true),
     ),
+    'incourse' => array(
+        'file' => 'columns2.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+        'options' => array('langmenu' => true),
+    ),
     // Standard layout with blocks.
     'standard' => array(
         'file' => 'columns2.php',

--- a/lang/en/theme_pimenko.php
+++ b/lang/en/theme_pimenko.php
@@ -235,6 +235,10 @@ $string['entercourse'] = 'Enter';
 $string['moodleactivitycompletion']      = "Enable display of moodle activity completion";
 $string['moodleactivitycompletion_desc'] = "This option enables the default display of the activity completion used by moodle";
 
+// Show or not navigation in mod in course.
+$string['showactivitynavigation']      = "Show previous/next navigation for mods";
+$string['showactivitynavigation_desc'] = "This option allows you to show or hide the previous/next navigation in the activities";
+
 // Setting show participant tab or no.
 $string['showparticipantscourse']      = "Display the participant section in the secondary menu visible in the courses";
 $string['showparticipantscourse_desc'] = "This option allows you to show or hide the 'Participants' section which is displayed by default in the secondary menu of the home page of a course.";

--- a/lang/fr/theme_pimenko.php
+++ b/lang/fr/theme_pimenko.php
@@ -238,6 +238,10 @@ $string['moodleactivitycompletion_desc'] = "Dans les activités ou les ressource
 $string['showparticipantscourse']      = "Afficher la rubrique participant dans le menu secondaire visible dans les cours";
 $string['showparticipantscourse_desc'] = "Cette option permet d'afficher ou de masquer la rubrique 'Participants' qui s’affiche par défaut dans le menu secondaire de la page d'accueil d'un cours.";
 
+// Show or not navigation in mod in course.
+$string['showactivitynavigation']      = "Afficher la navigation précédent/suivant pour les mods";
+$string['showactivitynavigation_desc'] = "Cette option permet d'afficher ou de masquer la navigation précédent/suivant dans les activités";
+
 $string['totop'] = 'Aller en haut';
 $string['listuserrole'] = 'Liste des rôles';
 $string['listuserrole_desc'] = 'Si l\'option showparticipantscourse est activé définisser les utilisateurs pouvant voir l\'onglet participants';

--- a/layout/columns2.php
+++ b/layout/columns2.php
@@ -91,7 +91,6 @@ $templatecontext = [
     'hasblocks' => $hasblocks,
     'bodyattributes' => $bodyattributes,
     'regionmainsettingsmenu' => $regionmainsettingsmenu,
-    'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu),
     'primarymoremenu' => $primarymenu['moremenu'],
     'secondarymoremenu' => $secondarynavigation ?: false,
     'blockdraweropen' => $blockdraweropen,

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -97,7 +97,6 @@ $templatecontext = [
         'usermenu' => $primarymenu['user'],
         'langmenu' => $primarymenu['lang'],
         'regionmainsettingsmenu' => $regionmainsettingsmenu,
-        'hasregionmainsettingsmenu' => !empty($regionmainsettingsmenu),
         'hasfrontpageregions' => !empty($hasfrontpageregions),
         'iscarouselenabled' => $iscarouselenabled,
         'primarymoremenu' => $primarymenu['moremenu'],

--- a/settings.php
+++ b/settings.php
@@ -152,6 +152,24 @@ if ($ADMIN->fulltree) {
     $setting->set_updatedcallback('theme_reset_all_caches');
     $page->add($setting);
 
+    // Show or not navigation in mod in course.
+    $name = 'theme_pimenko/showactivitynavigation';
+    $title = get_string(
+        'showactivitynavigation',
+        'theme_pimenko'
+    );
+    $description = get_string(
+        'showactivitynavigation_desc',
+        'theme_pimenko'
+    );
+    $setting = new admin_setting_configcheckbox(
+        $name,
+        $title,
+        $description,
+        true
+    );
+    $page->add($setting);
+
     // Show or not participants node in course.
     $name = 'theme_pimenko/showparticipantscourse';
     $title = get_string(

--- a/templates/frontpage.mustache
+++ b/templates/frontpage.mustache
@@ -29,7 +29,6 @@
     * hasblocks - true if there are blocks on this page
     * navdraweropen - true if the nav drawer should be open on page load
     * regionmainsettingsmenu - HTML for the region main settings menu
-    * hasregionmainsettingsmenu - There is a region main settings menu on this page.
 
     Example context (json):
     {
@@ -45,7 +44,6 @@
         "hasblocks":true,
         "navdraweropen":true,
         "regionmainsettingsmenu": "",
-        "hasregionmainsettingsmenu": false
     }
 }}
 {{> theme_boost/head }}
@@ -135,16 +133,7 @@
                 </div>
             {{/hasfrontpageregions}}
             <div id="region-main-box" class="col-12 moodle-region">
-                {{#hasregionmainsettingsmenu}}
-                    <div id="region-main-settings-menu"
-                         class="hidden-print">
-                        <div> {{{ output.region_main_settings_menu }}} </div>
-                    </div>
-                {{/hasregionmainsettingsmenu}}
                 <section id="region-main" class="container-fluid">
-                    {{#hasregionmainsettingsmenu}}
-                        <div class="region_main_settings_menu_proxy"></div>
-                    {{/hasregionmainsettingsmenu}}
                     {{{ output.course_content_header }}}
                     {{{ output.main_content }}}
                     {{{ output.activity_navigation }}}

--- a/templates/theme_boost/columns2.mustache
+++ b/templates/theme_boost/columns2.mustache
@@ -29,7 +29,6 @@
     * hasblocks - true if there are blocks on this page
     * navdraweropen - true if the nav drawer should be open on page load
     * regionmainsettingsmenu - HTML for the region main settings menu
-    * hasregionmainsettingsmenu - There is a region main settings menu on this page.
 
     Example context (json):
     {
@@ -45,7 +44,6 @@
         "hasblocks":true,
         "navdraweropen":true,
         "regionmainsettingsmenu": "",
-        "hasregionmainsettingsmenu": false
     }
 }}
 {{> theme_boost/head }}
@@ -132,16 +130,7 @@
             {{/secondarymoremenu}}
             <div id="page-content" class="pb-3 d-print-block">
                 <div id="region-main-box">
-                    {{#hasregionmainsettingsmenu}}
-                        <div id="region-main-settings-menu" class="d-print-none">
-                            <div> {{{ regionmainsettingsmenu }}} </div>
-                        </div>
-                    {{/hasregionmainsettingsmenu}}
                     <section id="region-main" aria-label="{{#str}}content{{/str}}">
-
-                        {{#hasregionmainsettingsmenu}}
-                            <div class="region_main_settings_menu_proxy"></div>
-                        {{/hasregionmainsettingsmenu}}
                         {{{ output.course_content_header }}}
                         {{{ output.main_content }}}
                         {{#output.show_activity_navigation}}

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = '2022040100';
+$plugin->version = '2022041200';
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = '2019111800';


### PR DESCRIPTION
- Add an option to show/hide navigation in mod
- Fix issue were course and 'incourse' layout were different
- Remove hasregionmainsettingsmenu not needed anymore since it is in second nav